### PR TITLE
Minor fix in desktop file

### DIFF
--- a/touchegg-gce.desktop
+++ b/touchegg-gce.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Categories=Settings
+Categories=Settings;
 TryExec=touchegg-gce
 Exec=touchegg-gce
 Name=Touchégg-GCE


### PR DESCRIPTION
Added trailing semicolon (';') to category key in
the desktop file. This is to avoid an error in the
rpmlint checking of RPM packages created for the app.